### PR TITLE
internal [202311][CMIS] Skip re-init flow for SW-controlled ports in case of fastboot

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -983,6 +983,7 @@ class TestXcvrdScript(object):
         assert task.get_configured_tx_power_from_db('Ethernet0') == -10
 
     @patch('xcvrd.xcvrd.platform_chassis')
+    @patch('xcvrd.xcvrd.is_fast_reboot_enabled', MagicMock(return_value=(False)))
     @patch('xcvrd.xcvrd_utilities.port_mapping.subscribe_port_update_event', MagicMock(return_value=(None, None)))
     @patch('xcvrd.xcvrd_utilities.port_mapping.handle_port_update_event', MagicMock())
     def test_CmisManagerTask_task_run_stop(self, mock_chassis):
@@ -1212,6 +1213,7 @@ class TestXcvrdScript(object):
 
     @patch('xcvrd.xcvrd.XcvrTableHelper.get_status_tbl')
     @patch('xcvrd.xcvrd.platform_chassis')
+    @patch('xcvrd.xcvrd.is_fast_reboot_enabled', MagicMock(return_value=(False)))
     @patch('xcvrd.xcvrd_utilities.port_mapping.subscribe_port_update_event', MagicMock(return_value=(None, None)))
     @patch('xcvrd.xcvrd_utilities.port_mapping.handle_port_update_event', MagicMock())
     @patch('xcvrd.xcvrd._wrapper_get_sfp_type', MagicMock(return_value='QSFP_DD'))

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1260,6 +1260,8 @@ class CmisManagerTask(threading.Thread):
         for lport in logical_port_list:
             self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_UNKNOWN)
 
+        is_fast_reboot = is_fast_reboot_enabled()
+
         # APPL_DB for CONFIG updates, and STATE_DB for insertion/removal
         sel, asic_context = port_mapping.subscribe_port_update_event(self.namespaces, helper_logger)
         while not self.task_stopping_event.is_set():
@@ -1402,11 +1404,17 @@ class CmisManagerTask(threading.Thread):
 
                         if self.port_dict[lport]['host_tx_ready'] != 'true' or \
                                 self.port_dict[lport]['admin_status'] != 'up':
-                           self.log_notice("{} Forcing Tx laser OFF".format(lport))
-                           # Force DataPath re-init
-                           api.tx_disable_channel(media_lanes_mask, True)
-                           self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_READY)
-                           continue
+                            if is_fast_reboot:
+                                self.log_notice("{} Skip re-init flow".format(lport))
+                                self.log_notice("{}: READY".format(lport))
+                                self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_READY)
+                                self.post_port_active_apsel_to_db(api, lport, host_lanes_mask)
+                            else:
+                                self.log_notice("{} Forcing Tx laser OFF".format(lport))
+                                # Force DataPath re-init
+                                api.tx_disable_channel(media_lanes_mask, True)
+                                self.update_port_transceiver_status_table_sw_cmis_state(lport, CMIS_STATE_READY)
+                            continue
                     # Configure the target output power if ZR module
                         if api.is_coherent_module():
                            tx_power = self.port_dict[lport]['tx_power']


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Skip the re-init flow for the SW-controlled ports in case of fastboot.
Because during fastboot the switch didn't reset the modules, so there is no need to reinitialize them.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
To improve the fastboot data-plane disruption time.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Run the [sonic-mgmt/tests/platform_tests/test_advanced_reboot.py::test_fast_reboot](https://github.com/sonic-net/sonic-mgmt/blob/de7ad768f74efb04301dccbfa004a5a109b84c91/tests/platform_tests/test_advanced_reboot.py#L62)

#### Additional Information (Optional)
